### PR TITLE
Add Total Input On Admin Page

### DIFF
--- a/admin/controller/payment/veritrans.php
+++ b/admin/controller/payment/veritrans.php
@@ -169,6 +169,11 @@ class ControllerPaymentVeritrans extends Controller {
       $this->error['display_name'] = $this->language->get('error_display_name');
     }
 
+    // check for empty values
+    if (!$this->request->post['veritrans_total']) {
+      $this->error['total'] = $this->language->get('error_total');
+    }
+
     // version-specific validation
     if ($version == 1)
     {

--- a/admin/language/english/payment/veritrans.php
+++ b/admin/language/english/payment/veritrans.php
@@ -42,4 +42,5 @@ $_['error_client_key']   = 'Client Key is required!';
 $_['error_server_key']   = 'Server Key is required!';
 $_['error_currency_conversion'] = 'Currency conversion rate is required when IDR currency is not installed in the system!';
 $_['error_display_name'] = 'Please specify a name for this payment method!';
+$_['error_total'] = 'Total is required!';
 ?>

--- a/admin/view/template/payment/veritrans.tpl
+++ b/admin/view/template/payment/veritrans.tpl
@@ -46,6 +46,16 @@
           </tr>
           <!-- Display name -->
 
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_total; ?></td>
+            <td><input type="text" name="veritrans_total" value="<?php echo $veritrans_total; ?>" />
+              <?php if (isset($error['total'])): ?>
+                <span class="error"><?php echo $error['total']; ?></span>
+              <?php endif; ?>
+            </td>
+          </tr>
+          <!-- Total -->
+
           <tr class="v2_settings sensitive">
             <td><span class="required">*</span> <?php echo $entry_environment; ?></td>
             <td>


### PR DESCRIPTION
I'm showing input for `veritrans_total` on admin page, it trigger url not found after payment confirm when `gross_amount` is less than 500000.

It's skipped condition checking on `catalog/model/payment/veritrans.php`, but showing veritrans on payment method selection.
>if ($this->config->get('veritrans_total') > 0 && $this->config->get('veritrans_total') > $total) {
>			$status = false;


After that in file `catalog/controller/payment/veritrans.php`  it always enter condition `gross_amount < 500000` at line 277 causing the user to get page not found when confirm.

>         if ($is_installment) {
>        $warningUrl = 'index.php?route=information/warning&redirLink=';
>
>       if ($num_products > 1) {
>        $redirUrl = $warningUrl . $redirUrl . '&message=1';
>        }
>        else if ($transaction_details['gross_amount'] < 500000) {
>          $redirUrl = $warningUrl . $redirUrl . '&message=2';
>        }
>      }
>      else if ($this->config->get('veritrans_installment_option') == 'all_product' &&
>          ($transaction_details['gross_amount'] < 500000)) {
>        $warningUrl = 'index.php?route=information/warning&redirLink=';
>        $redirUrl = $warningUrl . $redirUrl . '&message=2';
>      }

