### PR TITLE
Added finish-unfinish-error url (landing page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Official Veritrans OpenCart Extension
+Official Veritrans OpenCart (v1.5.x.x & lower) Extension
 ===================================
 
 Veritrans :heart: OpenCart!
@@ -19,11 +19,11 @@ This is the official Veritrans extension for the OpenCart E-commerce platform.
 
   * **Payment Notification URL** in Settings to `http://[your shop's homepage]/index.php?route=payment/veritrans/payment_notification`
 
-  * **Finish Redirect URL** in Settings to `http://[your shop's homepage]/index.php?route=checkout/success&`
+  * **Finish Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
-  * **Error Redirect URL** in Settings to `http://[your shop's homepage]/index.php`
+  * **Error Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
-  * **Unfinish Redirect URL** in Settings to `http://[your shop's homepage]/index.php`
+  * **Unfinish Redirect URL** in Settings to `http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&`
 
 #### Get help
 

--- a/catalog/language/english/payment/veritrans.php
+++ b/catalog/language/english/payment/veritrans.php
@@ -1,13 +1,13 @@
 <?php
 // Text
 // Heading
-$_['heading_title']     = 'Thank you for shopping with %s .... ';
+$_['heading_title']     = 'Thank you for shopping with us ';
 
 // Text
 $_['text_title']        = 'Credit Card IDR Veritrans';
 $_['text_response']     = 'Response from Veritrans:';
 $_['text_success']      = '... your payment was successfully received.';
 $_['text_success_wait'] = '<b><span style="color: #FF0000">Please wait...</span></b> whilst we finish processing your order.<br>If you are not automatically re-directed in 10 seconds, please click <a href="%s">here</a>.';
-$_['text_failure']      = '... Your payment has been cancelled!';
+$_['text_failure']      = 'Sorry! Your payment has failed! Please do re-checkout or contact administrator/support ';
 $_['text_failure_wait'] = '<b><span style="color: #FF0000">Please wait...</span></b><br>If you are not automatically re-directed in 10 seconds, please click <a href="%s">here</a>.';
 ?>

--- a/catalog/view/theme/default/template/payment/veritrans_checkout_failure.tpl
+++ b/catalog/view/theme/default/template/payment/veritrans_checkout_failure.tpl
@@ -1,7 +1,12 @@
 <?php echo $header; ?><?php echo $column_left; ?><?php echo $column_right; ?>
-<div id="content"><?php echo $content_top; ?>
-  <h2><?php echo $heading_title; ?></h2>
-  <p><?php echo $text_payment_failed ?></p>
-  <?php echo $content_bottom; ?>
+<div class="container"><?php echo $content_top; ?>
+	<h2 class="text-center">Payment Failed!</h2>
+	<p class="text-center"><?php echo $text_failure ?></p>
+	<a href="<?php echo $checkout_url;?>">
+		<div class="text-center">
+			<button class="btn btn-primary">Re-Checkout!</button>
+		</div>
+	</a><br/>
+	<?php echo $content_bottom; ?>
 </div>
 <?php echo $footer; ?>


### PR DESCRIPTION
- new `function landing_redir()` to handle redirection from VTWeb
- new `function failure()`, to handle failure payment
- relocated `cart->empty`, cart is emptied when customer reach payment success page after redirected from VTWeb
- locally tested, should be running as expected

## TODO
- update docs.veritrans.co.id for new finish-error-unfinish url which is :

``http://[your shop’s homepage]/index.php?route=payment/veritrans/landing_redir&``